### PR TITLE
Serve fonts from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,9 @@ Generates offers and invoices for Studs
 ## Setup
 Clone the repo and run `bundle` to install dependencies
 
+### Environment variables
+Fonts are fetched from a CDN of your choice. Set the environment variable `CDN_URL` to an url pointing to your bucket. 
+
 ## Usage
 Run the app with `rackup`
+

--- a/app.rb
+++ b/app.rb
@@ -25,14 +25,6 @@ get '/offer-2018.png' do
  send_file 'offer-2018.png'
 end
 
-get '/dincondensed.ttf' do
- send_file 'dincondensed.ttf'
-end
-
-get '/neuzeitslt.ttf' do
- send_file 'neuzeitslt.ttf'
-end
-
 get '/generate_offer' do
   haml :offer, locals: params.map {|k, v| v == '' ? [k.to_sym, nil] : [k.to_sym, v] }.to_h
 end

--- a/style.css
+++ b/style.css
@@ -10,16 +10,6 @@
   margin-left: 0;
 }
 
-@font-face {
-    font-family: 'Neuzeit S LT';
-    src: url(neuzeitslt.ttf);
-}
-
-@font-face {
-    font-family: 'DIN Condensed';
-    src: url(dincondensed.ttf);
-}
-
 html, body {
   padding: 0;
   margin: 0;
@@ -33,7 +23,6 @@ h1 {
   font-family: 'DIN Condensed';
   font-size: 16pt;
 }
-
 
 ul {
   list-style-type: none;

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -1,6 +1,7 @@
 !!!
 %html
   %head
+    %link{rel: 'stylesheet', href: "#{ENV['CDN_URL']}/fonts/stylesheet.css"}
     %link{rel: 'stylesheet', href: '/style.css'}
   %body
     = yield


### PR DESCRIPTION
Loads the font-faces declarations and font files from a CDN (Cloudfront / S3 in our case).

Requires the environment variable `CDN_URL` to be set